### PR TITLE
 feat: Make .file() return an object

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,16 +1,15 @@
 {
-  "env": {
-      "es6": true,
-      "node": true,
-      "browser": false
-  },
-  "parserOptions": {
-      "ecmaVersion": 2020
-  },
-  "extends": "airbnb-base",
-  "rules": {
-      "indent": [1, 4],
-      "import/prefer-default-export": [0],
-      "import/extensions": [0]
-  }
+    "extends": ["airbnb-base", "prettier"],
+    "plugins": ["prettier"],
+    "parser": "babel-eslint",
+    "parserOptions": {
+        "ecmaVersion": 2020,
+        "sourceType": "module"
+    },
+    "rules": {
+        "lines-between-class-members": [0],
+        "class-methods-use-this": [0],
+        "import/extensions": [0],
+        "strict": [0, "global"]
+    }
 }

--- a/README.md
+++ b/README.md
@@ -44,7 +44,11 @@ const client = new EikNodeClient({
 
 await client.load();
 
-// Will, for example, output: https://cdn.eik.dev/pkg/mymodue/2.4.1/path/script.js
+// Will, for example, output: 
+// {
+//   integrity: sha512-zHQjnDpMW7IKVyTpT9cOPT1+xhUSOcbgXj6qHCPSPu1CbQfgwDEsIniXU54zDIN71zqmxLSp3hfIljpt69ok0w==
+//   value: https://cdn.eik.dev/pkg/mymodue/2.4.1/path/script.js   
+// }
 client.file('/path/script.js')
 ```
 
@@ -60,7 +64,11 @@ const client = new EikNodeClient({
 
 await client.load();
 
-// Will output: http://localhost:8080/public/path/script.js
+// Will, for example, output: 
+// {
+//   integrity: null
+//   value: http://localhost:8080/public/path/script.js
+// }
 client.file('/path/script.js')
 ```
 
@@ -117,6 +125,16 @@ Constructs a full URL to an asset. The URL is built up by appending the value of
 | ----------- | --------------- | ---------- | -------- | -------------------------------------------------------------------------------- |
 | file        | `null`          | `string`   | `false`  | File to append to the base of a full URL to an asset                             |
 
+Returns a object with as follow:
+
+```js
+{
+  integrity: sha512-zHQjnDpMW7IKVyTpT9cOPT1+xhUSOcbgXj6qHCPSPu1CbQfgwDEsIniXU54zDIN71zqmxLSp3hfIljpt69ok0w==
+  value: https://cdn.eik.dev/pkg/mymodue/2.4.1/path/script.js   
+}
+```
+
+If `integrity` of the file is not available, the value for `integrity` will be `null`. This will be the case when in development mode since integrity is calculated upon publish of a package to a Eik server.
 
 ### .maps()
 

--- a/README.md
+++ b/README.md
@@ -129,8 +129,8 @@ Returns a object with as follow:
 
 ```js
 {
-  integrity: sha512-zHQjnDpMW7IKVyTpT9cOPT1+xhUSOcbgXj6qHCPSPu1CbQfgwDEsIniXU54zDIN71zqmxLSp3hfIljpt69ok0w==
-  value: https://cdn.eik.dev/pkg/mymodue/2.4.1/path/script.js   
+  integrity: 'sha512-zHQjnDpMW7IKVyTpT9cOPT1+xhUSOcbgXj6qHCPSPu1CbQfgwDEsIniXU54zDIN71zqmxLSp3hfIljpt69ok0w==',
+  value: 'https://cdn.eik.dev/pkg/mymodue/2.4.1/path/script.js'
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -38,8 +38,8 @@
   "homepage": "https://github.com/eik-lib/node-client#readme",
   "dependencies": {
     "@eik/common": "4.0.0-next.4",
-    "node-fetch": "2.6.1",
-    "abslog": "2.4.0"
+    "abslog": "2.4.0",
+    "node-fetch": "2.6.1"
   },
   "devDependencies": {
     "@semantic-release/changelog": "5.0.1",
@@ -53,6 +53,7 @@
     "eslint-config-prettier": "8.1.0",
     "eslint-plugin-import": "2.22.1",
     "eslint-plugin-prettier": "3.3.1",
+    "babel-eslint": "10.1.0",
     "prettier": "2.2.1",
     "rollup": "2.40.0",
     "semantic-release": "17.4.1",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -2,6 +2,7 @@ export default {
     input: 'src/index.js',
     external: [
         '@eik/common',
+        'node-fetch',
         'abslog',
         'path',
     ],

--- a/src/asset.js
+++ b/src/asset.js
@@ -1,0 +1,40 @@
+const inspect = Symbol.for('nodejs.util.inspect.custom');
+
+export default class EikAsset {
+    #integrity;
+    #value;
+
+    constructor({
+        value = '',
+    } = {}) {
+        this.#integrity = null;
+        this.#value = value;
+    }
+    
+    get integrity() {
+        return this.#integrity;
+    }
+
+    set integrity(value) {
+        this.#integrity = value;
+    }
+
+    get value() {
+        return this.#value;
+    }
+
+    set value(value) {
+        this.#value = value;
+    }
+
+    toJSON() {
+        return {
+            integrity: this.#integrity,
+            value: this.#value,
+        }
+    }
+
+    [inspect]() {
+        return this.toJSON();
+    }
+}

--- a/src/asset.js
+++ b/src/asset.js
@@ -1,6 +1,6 @@
 const inspect = Symbol.for('nodejs.util.inspect.custom');
 
-export default class EikAsset {
+export default class Asset {
     #integrity;
     #value;
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 import { helpers } from '@eik/common';
 import { join } from 'path';
 import fetch from 'node-fetch';
+import EikAsset from './asset.js';
 
 const isUrl = (value = '') => value.startsWith('http');
 
@@ -72,14 +73,20 @@ export default class EikNodeClient {
     }
 
     file(file = '') {
+        const asset = new EikAsset();
+
         if (this.pDevelopment) {
             if (isUrl(this.pBase)) {
                 const base = new URL(this.pBase);
-                return new URL(join(base.pathname, file), base).href;
+                asset.value = new URL(join(base.pathname, file), base).href;
+            } else {
+                asset.value = join(this.pBase, file);
             }
-            return join(this.pBase, file);
+        } else {
+            asset.value = new URL(join(this.pathname, file), this.server).href;
         }
-        return new URL(join(this.pathname, file), this.server).href;
+        
+        return asset;
     }
 
     maps() {

--- a/test/asset.js
+++ b/test/asset.js
@@ -1,0 +1,44 @@
+import tap from 'tap';
+import Asset from '../src/asset.js';
+
+tap.test('Asset - Default values', (t) => {
+    const asset = new Asset();
+    t.equal(asset.integrity, null, 'should be "null"');
+    t.equal(asset.value, '', 'should be empty string');
+    t.end();
+});
+
+tap.test('Asset - Set values through constructor', (t) => {
+    const asset = new Asset({
+        value: 'foo'
+    });
+    t.equal(asset.value, 'foo', 'should have set value');
+    t.end();
+});
+
+tap.test('Asset - Set values through setters', (t) => {
+    const asset = new Asset();
+    asset.integrity = 'bar';
+    asset.value = 'foo';
+    t.equal(asset.integrity, 'bar', 'should have set value');
+    t.equal(asset.value, 'foo', 'should have set value');
+    t.end();
+});
+
+tap.test('Asset - Stringify object with default values', (t) => {
+    const asset = new Asset();
+    const obj = JSON.parse(JSON.stringify(asset));
+    t.equal(obj.integrity, null, 'should be "null"');
+    t.equal(obj.value, '', 'should be empty string');
+    t.end();
+});
+
+tap.test('Asset - Stringify object with set values', (t) => {
+    const asset = new Asset();
+    asset.integrity = 'bar';
+    asset.value = 'foo';
+    const obj = JSON.parse(JSON.stringify(asset));
+    t.equal(obj.integrity, 'bar', 'should have set value');
+    t.equal(obj.value, 'foo', 'should have set value');
+    t.end();
+});


### PR DESCRIPTION
This changes the return value of the `.file()` method from being a `String` to an `Object` which looks like this:

```js
{
  integrity: 'sha512-zHQjnDpMW7IKVyTpT9cOPT1+xhUSOcbgXj6qHCPSPu1CbQfgwDEsIniXU54zDIN71zqmxLSp3hfIljpt69ok0w==',
  value: 'https://cdn.eik.dev/pkg/mymodue/2.4.1/path/script.js'
}
```
The main reason for this is to also be able to get hold of other values such as the integrity hashes so we can provide increased security for assets pulled from the CDN.