### PR TITLE
fix: Do not use getters and setters on public data object

### DIFF
--- a/src/asset.js
+++ b/src/asset.js
@@ -1,40 +1,8 @@
-const inspect = Symbol.for('nodejs.util.inspect.custom');
-
 export default class Asset {
-    #integrity;
-    #value;
-
     constructor({
         value = '',
     } = {}) {
-        this.#integrity = null;
-        this.#value = value;
-    }
-    
-    get integrity() {
-        return this.#integrity;
-    }
-
-    set integrity(value) {
-        this.#integrity = value;
-    }
-
-    get value() {
-        return this.#value;
-    }
-
-    set value(value) {
-        this.#value = value;
-    }
-
-    toJSON() {
-        return {
-            integrity: this.#integrity,
-            value: this.#value,
-        }
-    }
-
-    [inspect]() {
-        return this.toJSON();
+        this.integrity = null;
+        this.value = value;
     }
 }


### PR DESCRIPTION
Using `getters`and `setters` have some downsides when using object spreading and for data objects returned from public APIs we want to be able to use object spreading as an end user expects it to work. Iow; remove setters and getters in favor of using properties defined on the object itself.