### PR TITLE
fix: Make default value of integrity to be undefined

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "src"
   ],
   "scripts": {
-    "test": "tap --no-esm test/*.js --no-coverage",
+    "test": "tap test/*.js --no-coverage",
     "lint:fix": "eslint --fix .",
     "lint": "eslint .",
     "prepare": "npm run -s build",
@@ -48,15 +48,15 @@
     "@semantic-release/github": "7.2.0",
     "@semantic-release/npm": "7.0.10",
     "@semantic-release/release-notes-generator": "9.0.2",
+    "babel-eslint": "10.1.0",
     "eslint": "7.21.0",
     "eslint-config-airbnb-base": "14.2.1",
     "eslint-config-prettier": "8.1.0",
     "eslint-plugin-import": "2.22.1",
     "eslint-plugin-prettier": "3.3.1",
-    "babel-eslint": "10.1.0",
     "prettier": "2.2.1",
     "rollup": "2.40.0",
     "semantic-release": "17.4.1",
-    "tap": "14.11.0"
+    "tap": "15.0.2"
   }
 }

--- a/src/asset.js
+++ b/src/asset.js
@@ -2,7 +2,7 @@ export default class Asset {
     constructor({
         value = '',
     } = {}) {
-        this.integrity = null;
+        this.integrity = undefined;
         this.value = value;
     }
 }

--- a/test/asset.js
+++ b/test/asset.js
@@ -3,7 +3,7 @@ import Asset from '../src/asset.js';
 
 tap.test('Asset - Default values', (t) => {
     const asset = new Asset();
-    t.equal(asset.integrity, null, 'should be "null"');
+    t.equal(asset.integrity, undefined, 'should be "undefined"');
     t.equal(asset.value, '', 'should be empty string');
     t.end();
 });
@@ -28,7 +28,7 @@ tap.test('Asset - Set values through setters', (t) => {
 tap.test('Asset - Stringify object with default values', (t) => {
     const asset = new Asset();
     const obj = JSON.parse(JSON.stringify(asset));
-    t.equal(obj.integrity, null, 'should be "null"');
+    t.equal(obj.integrity, undefined, 'should be "undefined"');
     t.equal(obj.value, '', 'should be empty string');
     t.end();
 });


### PR DESCRIPTION
When doing serializing of the asset object, this should omit unset values causing it to not appear as an empty value (`null` or `''`).