### PR TITLE
feat: Add .base() method to retrieve a base URL to a package

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,11 +108,63 @@ This module has the following API
 
 ### async .load()
 
-Loads Eik config into the module. The config will be cached in the module. If `loadMaps` is set to `true` on the constructor, the import maps defined in the config will be loaded from the Eik server
+Loads Eik config from the Eik config into the object instance. If `loadMaps` is set to `true` on the constructor, the import maps defined in the config will be loaded from the Eik server. 
+
+### .base()
+
+Constructs a URL to the base of a package of assets. The returned value will differ depending on if development mode is set to true or not.
+
+When in non development mode, the returned value will be built up by the values found in the loaded Eik config and provide a URL to where the files can be expected to be on the Eik server.
+
+```js
+const client = new EikNodeClient({
+    development: false,
+    base: 'http://localhost:8080/assets'
+});
+await client.load();
+
+client.base()  // https://cdn.eik.dev/pkg/mymodue/2.4.1
+```
+
+When in development mode, the returned value will be equal to whats set on the `base` argument on the constructor.
+
+```js
+const client = new EikNodeClient({
+    development: true,
+    base: 'http://localhost:8080/assets'
+});
+await client.load();
+
+client.base()  // http://localhost:8080/assets
+```
 
 ### .file(file)
 
-Constructs a full URL to an asset. The URL is built up by appending the value of the `file` argument to a `base` root. By default (production mode) the `base` root is built up from values in Eik config matching where the package for the config are located on the Eik server. If the module is in development mode, the value set for `base` on the constructor will be used as the `base` root.
+Constructs a full URL to an asset. The URL is built up by appending the value of the `file` argument to a `base` root. The returned value will differ depending on if development mode is set to true or not.
+
+When in non development mode, the returned value will be built up by the values found in the loaded Eik config and provide a URL to where the files can be expected to be on the Eik server plus the provided value to the `file` argument on the method.
+
+```js
+const client = new EikNodeClient({
+    development: false,
+    base: 'http://localhost:8080/assets'
+});
+await client.load();
+
+client.file('/js/script.js')  // Returns an asset.value like: https://cdn.eik.dev/pkg/mymodue/2.4.1/js/script.js
+```
+
+When in development mode, the returned value will be equal to whats set on the `base` argument on the constructor plus the provided value to the `file` argument on the method.
+
+```js
+const client = new EikNodeClient({
+    development: true,
+    base: 'http://localhost:8080/assets'
+});
+await client.load();
+
+client.file('/js/script.js')  // Returns an asset.value like: http://localhost:8080/assets/js/script.js
+```
 
 #### arguments
 

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,10 @@ import { request } from 'undici';
 import { join } from 'path';
 import Asset from './asset.js';
 
-const isUrl = (value = '') => value.startsWith('http');
+const trimSlash = (value = '') => {
+    if (value.endsWith('/')) return value.substring(0, value.length - 1);
+    return value;
+}
 
 const fetchImportMaps = async (urls = []) => {
     try{
@@ -47,7 +50,7 @@ export default class NodeClient {
         this.#loadMaps = loadMaps;
         this.#config = {};
         this.#path = path;
-        this.#base = base;
+        this.#base = trimSlash(base);
         this.#maps = [];
     }
 
@@ -84,21 +87,16 @@ export default class NodeClient {
         throw new Error('Eik config was not loaded before calling .pathname');
     }
 
-    file(file = '') {
-        const asset = new Asset();
+    base() {
+        if (this.#development) return this.#base;
+        return `${this.server}${this.pathname}`;
+    }
 
-        if (this.#development) {
-            if (isUrl(this.#base)) {
-                const base = new URL(this.#base);
-                asset.value = new URL(join(base.pathname, file), base).href;
-            } else {
-                asset.value = join(this.#base, file);
-            }
-        } else {
-            asset.value = new URL(join(this.pathname, file), this.server).href;
-        }
-        
-        return asset;
+    file(file = '') {
+        const base = this.base();
+        return new Asset({
+            value: `${base}${file}`,
+        });
     }
 
     maps() {

--- a/test/index.js
+++ b/test/index.js
@@ -155,11 +155,11 @@ tap.test('Client - Retrieve a file path - Development mode is set to "false"', a
     const file = '/some/path/foo.js';
     const resolved = client.file(file);
 
-    t.equal(`${client.server}${client.pathname}${file}`, resolved.value);
+    t.equal(resolved.value, `${client.server}${client.pathname}${file}`);
     t.end();
 });
 
-tap.test('Client - Retrieve a file path - Development mode is set to "true"', async (t) => {
+tap.test('Client - Retrieve a file path - Development mode is set to "true" - Base is unset', async (t) => {
     const client = new NodeClient({
         development: true,
         path: t.context.fixture,
@@ -168,11 +168,11 @@ tap.test('Client - Retrieve a file path - Development mode is set to "true"', as
 
     const resolved = client.file('/some/path/foo.js');
 
-    t.equal('/some/path/foo.js', resolved.value);
+    t.equal(resolved.value, '/some/path/foo.js');
     t.end();
 });
 
-tap.test('Client - Retrieve a file path - Development mode is set to "true"', async (t) => {
+tap.test('Client - Retrieve a file path - Development mode is set to "true" - Base is set to absolute URL', async (t) => {
     const client = new NodeClient({
         development: true,
         base: 'http://localhost:7777/prefix/',
@@ -182,7 +182,7 @@ tap.test('Client - Retrieve a file path - Development mode is set to "true"', as
 
     const resolved = client.file('/some/path/foo.js');
 
-    t.equal('http://localhost:7777/prefix/some/path/foo.js', resolved.value);
+    t.equal(resolved.value, 'http://localhost:7777/prefix/some/path/foo.js');
     t.end();
 });
 
@@ -194,10 +194,63 @@ tap.test('Client - Load maps', async (t) => {
     await client.load();
     
     const maps = client.maps();
-    t.same([
+    t.same(maps, [
         { imports: { eik: '/src/eik.js' } },
         { imports: { eik: '/src/eik.js' } }
-    ], maps, 'Should return maps');
+    ], 'Should return maps');
 
+    t.end();
+});
+
+tap.test('Client - Retrieve a base - Development mode is set to "true" - Base is unset', async (t) => {
+    const client = new NodeClient({
+        development: true,
+        path: t.context.fixture,
+    });
+    await client.load();
+
+    const resolved = client.base();
+
+    t.equal(resolved, '', 'Should be an empty string');
+    t.end();
+});
+
+tap.test('Client - Retrieve a base - Development mode is set to "true" - Base is set to a relative URL', async (t) => {
+    const client = new NodeClient({
+        development: true,
+        base: '/prefix',
+        path: t.context.fixture,
+    });
+    await client.load();
+
+    const resolved = client.base();
+
+    t.equal(resolved, '/prefix');
+    t.end();
+});
+
+tap.test('Client - Retrieve a base - Development mode is set to "true" - Base is set to a absolute URL', async (t) => {
+    const client = new NodeClient({
+        development: true,
+        base: 'http://localhost:7777/prefix/some/path/',
+        path: t.context.fixture,
+    });
+    await client.load();
+
+    const resolved = client.base();
+
+    t.equal(resolved, 'http://localhost:7777/prefix/some/path');
+    t.end();
+});
+
+tap.test('Client - Retrieve a base - Development mode is set to "false"', async (t) => {
+    const client = new NodeClient({
+        path: t.context.fixture,
+    });
+    await client.load();
+
+    const resolved = client.base();
+
+    t.equal(resolved, `${t.context.address}/pkg/eik-fixture/1.0.2`);
     t.end();
 });


### PR DESCRIPTION
This adds a `.base()` method which will return a "base" or root URL to a module. The returned value will differ from when the module are in development mode which makes it possible to set a base point for where files are in local development and on the Eik server and then toggle between these.

Production mode:

```js
const client = new EikNodeClient({
    development: false,
    base: 'http://localhost:8080/assets'
});
await client.load();

client.base()  // https://cdn.eik.dev/pkg/mymodue/2.4.1
```

Development mode:

```js
const client = new EikNodeClient({
    development: true,
    base: 'http://localhost:8080/assets'
});
await client.load();

client.base()  // http://localhost:8080/assets
```

The behavior is the same as on the `.file()` method, but differ in the way that `.file()` will return an Asset object containing a full path and an Integrity hash to a file while the `.base()` method returns a URL to the root of a package as a String.