### PR TITLE
feat: Use the new @eik/common-config-loader module

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "homepage": "https://github.com/eik-lib/node-client#readme",
   "dependencies": {
-    "@eik/common": "3.0.1",
+    "@eik/common-config-loader": "4.0.0-next.8",
     "abslog": "2.4.0",
     "undici": "5.8.0"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
-import { helpers } from '@eik/common';
 import { request } from 'undici';
 import { join } from 'path';
+import loader from '@eik/common-config-loader';
 import Asset from './asset.js';
 
 const trimSlash = (value = '') => {
@@ -55,7 +55,7 @@ export default class NodeClient {
     }
 
     async load() {
-        this.#config = await helpers.getDefaults(this.#path);
+        this.#config = await loader.getDefaults(this.#path);
         if (this.#loadMaps) {
             this.#maps = await fetchImportMaps(this.#config.map);
         }

--- a/test/index.js
+++ b/test/index.js
@@ -1,5 +1,5 @@
 import { mkdtemp, writeFile } from 'fs/promises';
-import { helpers } from '@eik/common';
+import loader from '@eik/common-config-loader';
 import path from 'path';
 import http from 'http';
 import tap from 'tap';
@@ -8,7 +8,7 @@ import os from 'os';
 import NodeClient from '../src/index.js';
 
 const FIXTURE_PATH = `${process.cwd()}/fixtures`;
-const FIXTURE_FILE = await helpers.getDefaults(FIXTURE_PATH);
+const FIXTURE_FILE = await loader.getDefaults(FIXTURE_PATH);
 
 const writeTempConfig = async (address) => {
     const pathname = await mkdtemp(path.join(os.tmpdir(), `eik-${address.port.toString()}-`));


### PR DESCRIPTION
This replaces the `@eik/common` module with the new `@eik/common-config-loader` module.