### PR TITLE
fix:add starting slash to file-urls

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 import { helpers } from '@eik/common';
 import { request } from 'undici';
 import { join } from 'node:path';
-import { URL, resolve as resolveURL } from 'node:url';
+import { URL } from 'node:url';
 import Asset from './asset.js';
 
 const trimSlash = (value = '') => {
@@ -30,7 +30,6 @@ const fetchImportMaps = async (urls = []) => {
         });
         return await Promise.all(maps);
     } catch (err) {
-        console.log('ERROR', urls)
         throw new Error(
             `Unable to load import map file from server: ${err.message}`,
         );

--- a/test/index.js
+++ b/test/index.js
@@ -186,6 +186,34 @@ tap.test('Client - Retrieve a file path - Development mode is set to "true" - Ba
     t.end();
 });
 
+tap.test('Client - Retrieve a file path - Development mode is set to "true" - Base is set to absolute URL - file without starting slash', async (t) => {
+    const client = new NodeClient({
+        development: true,
+        base: 'http://localhost:7777/prefix/',
+        path: t.context.fixture,
+    });
+    await client.load();
+
+    const resolved = client.file('some/path/foo.js');
+
+    t.equal(resolved.value, 'http://localhost:7777/prefix/some/path/foo.js');
+    t.end();
+});
+
+tap.test('Client - Retrieve a file path - Development mode is set to "true" - Base is set to relative path - file without starting slash', async (t) => {
+    const client = new NodeClient({
+        development: true,
+        base: '/prefix/',
+        path: t.context.fixture,
+    });
+    await client.load();
+
+    const resolved = client.file('some/path/foo.js');
+
+    t.equal(resolved.value, '/prefix/some/path/foo.js');
+    t.end();
+});
+
 tap.test('Client - Load maps', async (t) => {
     const client = new NodeClient({
         loadMaps: true,


### PR DESCRIPTION
Currently we will receive a url without a slash delimiter if we pass inn a relative url to the `file` method without a starting slash. With this fix the URL is correct even if the starting slash is missing from the argument. It does not break any of the current tests, but we should consider if this is a breaking change.