### PR TITLE
test: serve test sever with ipv4 address 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ tmp/**/*
 *.log
 coverage
 .vscode
+dist/

--- a/test/index.js
+++ b/test/index.js
@@ -47,7 +47,7 @@ class Server {
 
     listen() {
         return new Promise((resolve) => {
-            const connection = this.server.listen(0, 'localhost', () => {
+            const connection = this.server.listen(0, '127.0.0.1', () => {
                 resolve(connection);
             });
         });


### PR DESCRIPTION
It defaulted to ::1, which broke URL parsing