### PR TITLE
feat: add toHTML function

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,13 +200,6 @@ const client = new Eik({
 await client.load();
 
 const maps = client.maps();
-const combined = maps.reduce((map, acc) => ({ ...acc, ...map }), {});
-
-const html = `
-<script type="importmap">
-${JSON.stringify(combined, null, 2)}
-</script>
-`;
 ```
 
 #### returns

--- a/README.md
+++ b/README.md
@@ -257,6 +257,33 @@ await client.load();
 client.base(); // http://localhost:8080/assets
 ```
 
+### .toHTML()
+
+Constructs an HTML import map script tag for use in the document head when doing import mapping.
+
+```js
+const client = new Eik({
+	loadMaps: true,
+	...
+});
+await client.load();
+
+const html = `
+	<html>
+	<head>
+		...
+		${client.toHTML()}
+		...
+	</head>
+	<body>
+		...
+	</body>
+	</html>
+`;
+```
+
+Due to browsers being restricted to a single import map, all import maps registered in eik.json or package.json will be merged down into a single import map with last in winning in case of duplicate keys.
+
 ## License
 
 Copyright (c) 2021 FINN.no

--- a/src/index.js
+++ b/src/index.js
@@ -298,8 +298,9 @@ export default class Eik {
 	/**
 	 * Function that generates and returns an import map script tag for use in an document head.
 	 *
-	 * Currently only a single import map is supported in the browser so we need to merge together import map objects into a single object
-	 * by using a JS Map object. Last in wins so order of import maps defined in eik.json is important if multiple maps share the same entries.
+	 * Only a single import map is allowed per HTML document.
+	 * A key (ex. `react`) can only be defined once.
+	 * If multiple import maps defined in `eik.json` use the same key the last one wins.
 	 *
 	 * @example
 	 * ```

--- a/src/index.js
+++ b/src/index.js
@@ -269,23 +269,12 @@ export default class Eik {
 	 *
 	 * @example
 	 * ```js
-	 * // generate a <script type="importmap">
-	 * // for import mapping in the browser
 	 * const client = new Eik({
 	 *   loadMaps: true,
 	 * });
 	 * await client.load();
 	 *
 	 * const maps = client.maps();
-	 * const combined = maps
-	 *   .map((map) => map.imports)
-	 *   .reduce((map, acc) => ({ ...acc, ...map }), {});
-	 *
-	 * const html = `
-	 * <script type="importmap">
-	 * ${JSON.stringify(combined, null, 2)}
-	 * </script>
-	 * `;
 	 * ```
 	 */
 	maps() {
@@ -300,7 +289,7 @@ export default class Eik {
 	 *
 	 * Only a single import map is allowed per HTML document.
 	 * A key (ex. `react`) can only be defined once.
-	 * If multiple import maps defined in `eik.json` use the same key the last one wins.
+	 * If multiple import maps defined in `eik.json` use the same key, the last key wins.
 	 *
 	 * @example
 	 * ```

--- a/src/index.js
+++ b/src/index.js
@@ -294,4 +294,35 @@ export default class Eik {
 			'Eik config was not loaded or "loadMaps" is "false" when calling .maps()',
 		);
 	}
+
+	/**
+	 * Function that generates and returns an import map script tag for use in an document head.
+	 *
+	 * Currently only a single import map is supported in the browser so we need to merge together import map objects into a single object
+	 * by using a JS Map object. Last in wins so order of import maps defined in eik.json is important if multiple maps share the same entries.
+	 *
+	 * @example
+	 * ```
+	 * const importMap = eik.toHTML();
+	 *
+	 * <head>
+	 *   ...
+	 *   ${importMap}
+	 *   ...
+	 * </head>
+	 * ```
+	 *
+	 * @returns {string}
+	 */
+	toHTML() {
+		const allImportMapKeyValuePairs = this.maps().flatMap((map) =>
+			Object.entries(map.imports),
+		);
+		const mergedAndDedupedImportMapObject = Object.fromEntries(
+			new Map(allImportMapKeyValuePairs).entries(),
+		);
+		return `<script type="importmap">${JSON.stringify({
+			imports: mergedAndDedupedImportMapObject,
+		})}</script>`;
+	}
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -342,3 +342,23 @@ tap.test(
 		t.end();
 	},
 );
+
+tap.test(
+	"Client - toHTML - import maps merged and script tag created",
+	async (t) => {
+		const client = new Eik({
+			loadMaps: true,
+			path: t.context.fixture,
+		});
+		await client.load();
+
+		const resolved = client.toHTML();
+
+		t.same(
+			resolved,
+			`<script type="importmap">${JSON.stringify({ imports: { eik: "/src/eik.js" } })}</script>`,
+			"Should return an import map script tag",
+		);
+		t.end();
+	},
+);


### PR DESCRIPTION
I decided to give this approach to client side import mapping a shot.

Essentially, the Node client fetches the import maps you have listed in the import-map field of your eik.json file and then the .toHTML method merges the contents of all import maps fetched and produces a script tag ready for the document head.

```js
const scriptTagMarkupString = eik.toHTML();
```