### PR TITLE
fix: slugify image type

### DIFF
--- a/fixtures/eik-image.json
+++ b/fixtures/eik-image.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://raw.githubusercontent.com/eik-lib/common/main/lib/schemas/eikjson.schema.json",
+  "name": "eik-image-fixture",
+  "version": "1.0.0",
+  "server": "https://cdn.eik.dev",
+  "type": "image",
+  "files": "./images"
+}

--- a/src/index.js
+++ b/src/index.js
@@ -186,7 +186,12 @@ export default class Eik {
 	 */
 	get pathname() {
 		if (this.#config.type && this.#config.name && this.#config.version)
-			return join("/", this.type, this.name, this.version).replace(/\\/g, "/");
+			return join(
+				"/",
+				helpers.typeSlug(this.type),
+				this.name,
+				this.version,
+			).replace(/\\/g, "/");
 		throw new Error("Eik config was not loaded before calling .pathname");
 	}
 

--- a/test/image.test.js
+++ b/test/image.test.js
@@ -1,0 +1,65 @@
+/// <reference path="../types/index.d.ts" />
+
+import tap from "tap";
+
+import Eik from "../src/index.js";
+
+const FIXTURE_PATH = `${process.cwd()}/fixtures/eik-image.json`;
+
+tap.test("image namespace is mapped correctly to /img", async (t) => {
+	const client = new Eik({
+		base: "/public/images",
+		path: FIXTURE_PATH,
+	});
+	await client.load();
+
+	t.equal("/img/eik-image-fixture/1.0.0", client.pathname);
+});
+
+tap.test("image asset is mapped correctly", async (t) => {
+	const client = new Eik({
+		path: FIXTURE_PATH,
+	});
+	await client.load();
+
+	const file = "/art/such.webp";
+	const resolved = client.file(file);
+
+	t.equal(
+		resolved.value,
+		`${client.server}/img/eik-image-fixture/1.0.0/art/such.webp`,
+	);
+	t.end();
+});
+
+tap.test('development mode is set to "true" - base is unset', async (t) => {
+	const client = new Eik({
+		development: true,
+		path: FIXTURE_PATH,
+	});
+	await client.load();
+
+	const file = "/art/such.webp";
+	const resolved = client.file(file);
+
+	t.equal(resolved.value, "/art/such.webp");
+	t.end();
+});
+
+tap.test(
+	'Cdevelopment mode is set to "true" - base is set to absolute URL',
+	async (t) => {
+		const client = new Eik({
+			development: true,
+			base: "http://localhost:7777/img/",
+			path: FIXTURE_PATH,
+		});
+		await client.load();
+
+		const file = "/art/such.webp";
+		const resolved = client.file(file);
+
+		t.equal(resolved.value, "http://localhost:7777/img/art/such.webp");
+		t.end();
+	},
+);


### PR DESCRIPTION
The pathname for the image namespace is supposed to be `/img`.
Add a test case as well to catch regressions.